### PR TITLE
Refactor version into setup.py

### DIFF
--- a/pymessagefocus/pymessagefocus.py
+++ b/pymessagefocus/pymessagefocus.py
@@ -1,5 +1,4 @@
 import xmlrpclib
-import version
 import re
 import six
 
@@ -7,7 +6,6 @@ import six
 # See: http://pymotw.com/2/xmlrpclib/
 
 class MessageFocusClient(object):
-    version = version.version
 
     ERROR_CODES = {# MessageFocus undeclared / unpublished fault codes:
                    '200': 'Request could not be processed. %s.',

--- a/pymessagefocus/version.py
+++ b/pymessagefocus/version.py
@@ -1,3 +1,0 @@
-version = '1.1.3'
-date = '22 July 2014'
-name = 'Lunar Sheriff'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 from distutils.core import setup
-import pymessagefocus
 
-setup(name=pymessagefocus.__name__,
-      version=pymessagefocus.MessageFocusClient.version,
-      packages=[pymessagefocus.__name__])
+setup(name='pymessagefocus',
+      version='1.1.4',
+      author='Triggered Messaging Ltd',
+      author_email='hello@triggeredmessaging.com',
+      license='LICENSE',
+      packages=['pymessagefocus'],
+      install_requires=['six']
+      )


### PR DESCRIPTION
Remove requirement to import pymessagefocus in the setup file as this in turn attempts to import an external dependency six which means the install will fail in a clean environment.
Remove version file entirely, all it's contents merged into setup.py

Relates to internal TMS case 5974
