### PR TITLE
Undo change to __init__.py

### DIFF
--- a/pymessagefocus/__init__.py
+++ b/pymessagefocus/__init__.py
@@ -1,0 +1,1 @@
+from pymessagefocus import *


### PR DESCRIPTION
Added import statement back in to grab MessageFocusClient and make it available on the module.

Was causing an error when importing the way that is shown in README.md
